### PR TITLE
csrf에 대한 잘못된 선언방법을 수정하였습니다.

### DIFF
--- a/04.MachineLearning/templates/inquiry.html
+++ b/04.MachineLearning/templates/inquiry.html
@@ -3,6 +3,7 @@
 {% block content %}
     <div class="content-section">
         <form method="post" action="">
+            {{ form.csrf_token }}
             {{ form.hidden_tag() }}
             
             <fieldset class="form-group">
@@ -68,7 +69,7 @@
     </div>
     {% endblock %}
     {% block additional_body %}
-    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
+        {# <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/> #}
     {% endblock %}
 
 


### PR DESCRIPTION
폼 태그안에 추가되어야 하며 RegistrationForm 객체를 사용해서 폼을 생성하였기때문에 아래 코드는 사용할 수 없습니다.